### PR TITLE
Support to Bignum

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ var _parse = function(buffer) {
         var bignum = bigInt.zero;
         for(var i = 0; i < length; i ++) {
           bignum = bignum.add(bigInt(buffer[offset + i]).multiply(bigInt(2).pow(i * 8)))
+          offset ++
         }
         return bignum.multiply(sign)
       default:

--- a/index.js
+++ b/index.js
@@ -9,8 +9,10 @@ var MARSHAL_SYM_REF = ';'.charCodeAt(0);
 var MARSHAL_INSTANCEVAR = 'I'.charCodeAt(0);
 var MARSHAL_IVAR_STR = '"'.charCodeAt(0);
 var MARSHAL_FLOAT = 'f'.charCodeAt(0);
+var MARSHAL_BIGNUM = 'l'.charCodeAt(0);
 
 var ints = require('./lib/ints');
+var bigInt = require('big-integer');
 
 var _parse = function(buffer) {
   var offset = 0;
@@ -106,7 +108,15 @@ var _parse = function(buffer) {
           hashOut[key] = val;
         }
         return hashOut;
-        break;
+      case MARSHAL_BIGNUM:
+        var sign = buffer[offset + 1] == 43 ? 1 : -1;
+        var length = ints.load(buffer.slice(offset + 2, offset + 3)) * 2;
+        offset += 3;
+        var bignum = bigInt.zero;
+        for(var i = 0; i < length; i ++) {
+          bignum = bignum.add(bigInt(buffer[offset + i]).multiply(bigInt(2).pow(i * 8)))
+        }
+        return bignum.multiply(sign)
       default:
         throw new Error('Unexpected data, value ' + buffer[offset].toString(16) + ' at offset ' + offset + ' on ' + buffer.toString('hex') + '. Parsing this sort of data is probably not yet implemented!');
     }
@@ -185,6 +195,10 @@ var _dump = function(value) {
           })
         )
       );
+    }
+
+    if(bigInt.isInstance(value)) {
+      throw new Error('Bignum dump is not yet implemented')
     }
 
     if(value === Object(value)) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "serialize",
     "unserialize"
   ],
+  "dependencies": {
+    "big-integer": "1.6.0"
+  },
   "devDependencies": {
     "mocha": "1.18.2"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var marsha = require('../');
 var assert = require('assert');
 var fs = require('fs');
+var bigInt = require('big-integer');
 var cases = JSON.parse(fs.readFileSync('./test/bidirectional_examples.json'));
 var complexCases = JSON.parse(fs.readFileSync('./test/other_examples.json'));
 
@@ -30,6 +31,16 @@ describe('marsha', function() {
     it('parses -Infinity', function() {
       var buffer = new Buffer('040866092d696e66', 'hex');
       assert.strictEqual(marsha.load(buffer), -Infinity);
+    });
+
+    it('parses Bignum', function() {
+      var buffer = new Buffer('04086c2b0968a0bf5909934051', 'hex');
+      assert.ok(marsha.load(buffer).equals(bigInt("5854841183951364200")));
+    });
+
+    it('parses negative Bignum', function() {
+      var buffer = new Buffer('04086c2d09fcecf6f9944a2b6a', 'hex');
+      assert.ok(marsha.load(buffer).equals(bigInt("-7650290395728243964")));
     });
 
     Object.keys(cases).forEach(function(hex) {
@@ -64,6 +75,16 @@ describe('marsha', function() {
     it('outputs -Infinity', function() {
       var buffer = marsha.dump(-Infinity);
       assert.equal(buffer.toString('hex'), '040866092d696e66');
+    });
+
+    xit('outputs Bignum', function() {
+      var buffer = marsha.dump(bigInt("5854841183951364200"));
+      assert.equal(buffer.toString('hex'), '04086c2b0968a0bf5909934051');
+    });
+
+    xit('outputs negative Bignum', function() {
+      var buffer = marsha.dump(bigInt("-7650290395728243964"));
+      assert.equal(buffer.toString('hex'), '04086c2d09fcecf6f9944a2b6a');
     });
 
     Object.keys(cases).forEach(function(hex) {


### PR DESCRIPTION
Add support to parsing [Bignum](http://docs.ruby-lang.org/en/2.1.0/marshal_rdoc.html#label-Bignum) using BigInteger.js. Dump is not yet implemented.
